### PR TITLE
refactor!: remove and replace all unneeded polyfills

### DIFF
--- a/.changeset/early-emus-eat.md
+++ b/.changeset/early-emus-eat.md
@@ -1,0 +1,5 @@
+---
+"browserify-util": patch
+---
+
+refactor!: remove and replace all unneeded polyfills

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,12 @@ jobs:
       - name: Install Dependencies
         run: npm install
 
-      - name: Publish to npm
+      - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@v1
         with:
+          commit: 'chore: release browserify-util'
+          title: 'chore: release browserify-util'
+          version: npx @changesets/cli version
           publish: npx @changesets/cli publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,4 +36,4 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Sync to cnpm
-        run: npx cnpm sync browserify
+        run: npx cnpm sync browserify-util

--- a/package.json
+++ b/package.json
@@ -13,20 +13,15 @@
     "./support/isBuffer.js": "./support/isBufferBrowser.js"
   },
   "dependencies": {
-    "inherits": "^2.0.3",
-    "is-arguments": "^1.0.4",
-    "is-generator-function": "^1.0.7",
-    "is-typed-array": "^1.1.3",
-    "which-typed-array": "^1.1.2"
+    "@nolyfill/is-generator-function": "^1.0.24",
+    "@nolyfill/which-typed-array": "^1.0.24",
+    "inherits": "^2.0.3"
   },
   "devDependencies": {
     "airtap": "~1.0.0",
     "core-js": "^3.6.5",
     "is-async-supported": "~1.2.0",
-    "object.assign": "~4.1.0",
-    "object.entries": "^1.1.0",
     "run-series": "~1.1.4",
-    "safe-buffer": "^5.1.2",
     "tape": "~4.9.0"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -44,5 +44,8 @@
     "test:browsers:with-polyfills": "airtap test/browser/with-polyfills.js",
     "test:browsers:with-polyfills:local": "npm run test:browsers:with-polyfills -- --local",
     "test:browsers:local": "npm run test:browsers -- --local"
+  },
+  "engines": {
+    "node": ">=12.6.0"
   }
 }

--- a/support/types.js
+++ b/support/types.js
@@ -3,10 +3,12 @@
 
 'use strict';
 
-var isArgumentsObject = require('is-arguments');
-var isGeneratorFunction = require('is-generator-function');
-var whichTypedArray = require('which-typed-array');
-var isTypedArray = require('is-typed-array');
+var isArgumentsObject = function (value) { return Object.prototype.toString.call(value) === '[object Arguments]'; };
+var isGeneratorFunction = require('@nolyfill/is-generator-function');
+var whichTypedArray = require('@nolyfill/which-typed-array');
+var isTypedArray = function isTypedArray(value) {
+  return !!whichTypedArray(value);
+}
 
 function uncurryThis(f) {
   return f.call.bind(f);

--- a/support/types.js
+++ b/support/types.js
@@ -6,9 +6,7 @@
 var isArgumentsObject = function (value) { return Object.prototype.toString.call(value) === '[object Arguments]'; };
 var isGeneratorFunction = require('@nolyfill/is-generator-function');
 var whichTypedArray = require('@nolyfill/which-typed-array');
-var isTypedArray = function isTypedArray(value) {
-  return !!whichTypedArray(value);
-}
+var isTypedArray = value => !!whichTypedArray(value);
 
 function uncurryThis(f) {
   return f.call.bind(f);

--- a/support/types.js
+++ b/support/types.js
@@ -3,7 +3,7 @@
 
 'use strict';
 
-var isArgumentsObject = function (value) { return Object.prototype.toString.call(value) === '[object Arguments]'; };
+var isArgumentsObject = value => Object.prototype.toString.call(value) === '[object Arguments]';
 var isGeneratorFunction = require('@nolyfill/is-generator-function');
 var whichTypedArray = require('@nolyfill/which-typed-array');
 var isTypedArray = value => !!whichTypedArray(value);

--- a/test/node/debug.js
+++ b/test/node/debug.js
@@ -21,7 +21,7 @@
 
 'use strict';
 var assert = require('assert');
-var ObjectAssign = require('object.assign');
+var ObjectAssign = Object.assign;
 
 var modeArgv = process.argv[2]
 var sectionArgv = process.argv[3]

--- a/test/node/types.js
+++ b/test/node/types.js
@@ -16,8 +16,7 @@ var _require = require('../../'),
     types = _require.types;
 var vm = require('vm');
 
-var Buffer = require('safe-buffer').Buffer
-var objectEntries = require('object.entries');
+var objectEntries = Object.entries;
 
 // "polyfill" deepStrictEqual on Node 0.12 and below
 if (!assert.deepStrictEqual) {


### PR DESCRIPTION
The PR closes #2 

- Replace `is-arguments` with one line code
  ```js
  var isArgumentsObject = function (value) { return Object.prototype.toString.call(value) === '[object Arguments]'; };
  ``` 
- Replace `is-typed-array` with one line code
  ```js
  var isTypedArray = function isTypedArray(value) { return !!whichTypedArray(value); }
  ```
- Replace `is-generator-function` with `@nolyfill/is-generator-function`
  - There is no easy one-line code version of `isGeneratorFunction`
- Replace `which-typed-array` with `@nolyfill/which-typed-array`
  - There is no easy one-line code version of `whichTypedArray`
- Remove `object.assign` inside `devDependencies`
- Remove `object.entries` inside `devDependencies`
- Remove `safe-buffer` inside `devDependencies`
  - Node.js `Buffer` is already *safe* since Node.js 6.